### PR TITLE
fix: check for CloudEvents returned from @event fn

### DIFF
--- a/parliament/decorators.py
+++ b/parliament/decorators.py
@@ -23,6 +23,8 @@ def event(_func=None, *,
         @functools.wraps(func)
         def event_wrapper(*args, **kwargs):
             data = func(*args, **kwargs)
+            if isinstance(data, CloudEvent):
+                return data
             attributes = {
               "type": event_type,
               "source": event_source

--- a/tests/decorator_test.py
+++ b/tests/decorator_test.py
@@ -62,3 +62,21 @@ def test_event_data():
         return data
     ce = f("test value")
     assert ce.data == "test value"
+
+
+def test_handles_returned_events():
+    """
+    Test that the @event decorator can detect when a function
+    has returned a CloudEvent, and simply pass it on.
+    """
+    @event
+    def f() -> CloudEvent:
+        attributes = {
+          "type": "user.type",
+          "source": "/user/source"
+        }
+        return CloudEvent(attributes, "Hola!")
+    ce = f()
+    assert ce.data == "Hola!"
+    assert ce["type"] == "user.type"
+    assert ce["source"] == "/user/source"


### PR DESCRIPTION
Check to see if a function decorated with @event returns a CloudEvent.
If so, just return it instead of creating a new event.

Signed-off-by: Lance Ball <lball@redhat.com>