### PR TITLE
chore(requirements): update dependencies and CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
-cloudevents==1.2.0
-flake8==3.9.0
-pytest==6.2.3
-Flask==1.1.2
+cloudevents==1.7.0
+flake8==5.0.4
+pytest==7.2.0
+Flask==2.2.2
 coverage
 waitress
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-cloudevents==1.2.0
-Flask==1.1.2
+cloudevents==1.7.0
+Flask==2.2.2
 waitress


### PR DESCRIPTION
Updates the dependencies to

```
cloudevents==1.7.0
flake8==5.0.4
pytest==7.2.0
Flask==2.2.2
```

Also adds CI runs on pull requests, drops support for Python 3.6 and
adds support for 3.9 and 3.10.

/kind chore

Signed-off-by: Lance Ball <lball@redhat.com>