### PR TITLE
feat: set log level with env variable

### DIFF
--- a/parliament/server.py
+++ b/parliament/server.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import traceback
+import logging
 
 from flask import Flask, request
 from cloudevents.http import CloudEvent, from_http, to_binary
@@ -22,6 +23,7 @@ def create(func):
     Create a Flask app with kube health endpoints, exposing 'func' at /
     """
     app = Flask(__name__)
+    set_log_level(app, os.environ["LOG_LEVEL"])
 
     @app.route("/", methods=["POST"])
     def handle_post():
@@ -62,3 +64,22 @@ def invoke(func, context):
         traceback.print_exc()
         print("caught", err)
         return f"Function raised {err}", 500
+
+
+def set_log_level(app, level):
+    if level == "CRITICAL":
+        app.logger.setLevel(logging.CRITICAL)
+    elif level == "DEBUG":
+        app.logger.setLevel(logging.DEBUG)
+    elif level == "INFO":
+        app.logger.setLevel(logging.INFO)
+    elif level == "ERROR":
+        app.logger.setLevel(logging.ERROR)
+    elif level == "NOTSET":
+        app.logger.setLevel(logging.NOTSET)
+    elif level == "WARNING":
+        app.logger.setLevel(logging.WARNING)
+    elif level == "DISABLED":
+        app.logger.disabled = True
+    else:   # default
+        app.logger.setLevel(logging.WARNING)

--- a/parliament/server.py
+++ b/parliament/server.py
@@ -23,7 +23,7 @@ def create(func):
     Create a Flask app with kube health endpoints, exposing 'func' at /
     """
     app = Flask(__name__)
-    set_log_level(app, os.environ["LOG_LEVEL"])
+    set_log_level(app, os.environ.get("LOG_LEVEL", "WARNING"))
 
     @app.route("/", methods=["POST"])
     def handle_post():


### PR DESCRIPTION
hello. I'm currently using python knative functions with this template very well.

When I create python knative functions and try to connect it with some http webhook services that does not support cloudevent spec, it seems that I cannot handle a log comming from here;

https://github.com/boson-project/parliament/blob/0ec7dba52c4df815e30dc61646a05660577b86b6/parliament/server.py#L33

so I thought it would be convenient if we can handle Flask log level by environment variable provided in knative functions.

example usage when creating knative function (func.yaml)

```yaml
specVersion: 0.0.0
...
...
envs:
- name: LOG_LEVEL
  value: ERROR
annotations: {}
options: {}
labels: []
healthEndpoints:
  liveness: /health/liveness
  readiness: /health/readiness
created: 
invocation:
  format: http
```

